### PR TITLE
docs: clarify validation requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Python library for IBM MQ PCF automation (bootstrap placeholder).
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Status](#status)
 - [Repository layout](#repository-layout)
@@ -11,15 +12,18 @@ Python library for IBM MQ PCF automation (bootstrap placeholder).
 - [Validation](#validation)
 
 ## Purpose
+
 Establish a reusable Python library for PCF command handling. This repository
 is bootstrapped with minimal structure and is expected to evolve as the API is
 implemented.
 
 ## Status
+
 Pre-release. No published artifacts yet.
 
 ## Repository layout
-```
+
+```text
 docs/
 scripts/
 src/
@@ -27,15 +31,18 @@ tests/
 ```
 
 ## Branching and releases
+
 - `develop` is the integration branch.
 - Release branches are named `release/<major>.<minor>.x`.
 - Releases are tagged on release branches.
 
 ## Versioning
+
 - Uses the library versioning scheme (PEP 440).
 - `MAJOR.MINOR.PATCH` is stored in `pyproject.toml`.
 - Pre-releases use standard pre-release identifiers.
 
 ## Validation
+
 - Full validation: `python3 scripts/dev/validate_local.py`
 - Docs-only validation: `python3 scripts/dev/validate_docs.py`

--- a/docs/decisions/0001-repo-structure.md
+++ b/docs/decisions/0001-repo-structure.md
@@ -1,1 +1,3 @@
-...
+# Decision 0001: Repository structure
+
+Placeholder for the initial repository structure decision record.

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -1,1 +1,3 @@
-...
+# Development environment and tooling
+
+Placeholder for environment and tooling guidance.

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -1,1 +1,3 @@
-...
+# Development overview
+
+Placeholder for development guidance.

--- a/docs/development/tooling-dependencies.md
+++ b/docs/development/tooling-dependencies.md
@@ -1,1 +1,3 @@
-...
+# Development tooling dependencies
+
+Placeholder for toolchain dependency details.

--- a/docs/development/validation.md
+++ b/docs/development/validation.md
@@ -1,1 +1,3 @@
-...
+# Development validation
+
+Placeholder for validation guidance.

--- a/docs/operations/2026-01-20-bootstrap-log.md
+++ b/docs/operations/2026-01-20-bootstrap-log.md
@@ -1,21 +1,25 @@
 # 2026-01-20 Bootstrap Log
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Assumptions](#assumptions)
 - [Commands executed](#commands-executed)
 - [Manual edits](#manual-edits)
 
 ## Purpose
+
 Record the exact bootstrap steps used to create the `pymqpcf` repository.
 
 ## Assumptions
+
 - Repository created under the `wphillipmoore` GitHub account (public).
 - Default branch is `develop`.
 - Python virtual environment created at `.venv`.
 
 ## Commands executed
-```
+
+```bash
 mkdir -p /Users/pmoore/dev/github/pymqpcf
 git init -b develop
 
@@ -107,6 +111,7 @@ gh repo view wphillipmoore/pymqpcf --json defaultBranchRef
 ```
 
 ## Manual edits
+
 - Updated coverage target in `.github/workflows/ci.yml` to `pymqpcf`.
 - Updated coverage target in `scripts/dev/validate_local.py` to `pymqpcf`.
 - Updated the description in `scripts/dev/validate_version.py` to `pymqpcf`.

--- a/docs/operations/2026-01-21-uv-migration.md
+++ b/docs/operations/2026-01-21-uv-migration.md
@@ -1,21 +1,25 @@
 # 2026-01-21 UV migration log
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Context](#context)
 - [Commands executed](#commands-executed)
 - [Notes](#notes)
 
 ## Purpose
+
 Record the operational steps used to migrate pymqpcf from Poetry tooling to uv.
 
 ## Context
+
 - Repository: pymqpcf
 - Branch: feature/uv-migration
-- Issue: https://github.com/wphillipmoore/pymqpcf/issues/2
+- Issue: [wphillipmoore/pymqpcf#2](https://github.com/wphillipmoore/pymqpcf/issues/2)
 
 ## Commands executed
-```
+
+```bash
 python3 -m venv .venv
 source .venv/bin/activate && python3 -m pip install uv==0.9.26
 
@@ -29,6 +33,7 @@ rm poetry.lock
 ```
 
 ## Notes
+
 - uv 0.9.26 is the pinned toolchain version for this migration.
 - Dependency groups now use the `dependency-groups` table in `pyproject.toml`.
 - Requirements exports are derived from `uv.lock` and remain the audit inputs.

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -26,8 +26,8 @@
 - Validation is required for non-docs-only changes; run the canonical command below.
 - `python3 scripts/dev/validate_local.py`
 - Docs-only changes: `python3 scripts/dev/validate_docs.py`
-- Docs-only validation requires `markdownlint` `0.41.0` on the PATH or `npx`
-  to run the pinned version.
+- Docs-only validation requires `markdownlint` >= `0.41.0` on the PATH
+  (install via Homebrew).
 
 ## Tooling requirement
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -1,6 +1,7 @@
 # pymqpcf Repository Standards
 
 ## Table of Contents
+
 - [AI co-authors](#ai-co-authors)
 - [Repository profile](#repository-profile)
 - [Local validation](#local-validation)
@@ -8,10 +9,12 @@
 - [Local deviations](#local-deviations)
 
 ## AI co-authors
+
 - Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
 - Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
 
 ## Repository profile
+
 - repository_type: library
 - versioning_scheme: library
 - branching_model: library-release
@@ -19,13 +22,17 @@
 - supported_release_lines: current and previous
 
 ## Local validation
+
+- Validation is required for non-docs-only changes; run the canonical command below.
 - `python3 scripts/dev/validate_local.py`
 - Docs-only changes: `python3 scripts/dev/validate_docs.py`
 - Docs-only validation requires `markdownlint` `0.41.0` on the PATH or `npx`
   to run the pinned version.
 
 ## Tooling requirement
+
 - `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`).
 
 ## Local deviations
+
 None.

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,15 +1,20 @@
 # pymqpcf Standards and Conventions
 
 This repository follows the canonical standards at:
-https://github.com/wphillipmoore/standards-and-conventions
+[wphillipmoore/standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions)
 
 ## Table of Contents
+
 - [Canonical references](#canonical-references)
 - [Project-specific overlay](#project-specific-overlay)
 
 ## Canonical references
+
+<!-- markdownlint-disable MD018 -->
 #include ../standards-and-conventions/docs/standards-and-conventions.md
+<!-- markdownlint-enable MD018 -->
 
 ## Project-specific overlay
+
 Project-specific content lives in `docs/repository-standards.md` and is
 included from `AGENTS.md` only.

--- a/scripts/dev/validate_docs.py
+++ b/scripts/dev/validate_docs.py
@@ -85,7 +85,7 @@ def resolve_markdownlint() -> tuple[str, str]:
 
 def run_markdownlint(paths: list[str]) -> int:
     """Run markdownlint using the resolved toolchain."""
-    markdownlint_cmd, version = resolve_markdownlint()
+    markdownlint_cmd, _version = resolve_markdownlint()
 
     if not paths:
         print("No markdown files found to validate.")

--- a/scripts/dev/validate_docs.py
+++ b/scripts/dev/validate_docs.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-MARKDOWNLINT_VERSION = "0.41.0"
+MIN_MARKDOWNLINT_VERSION = "0.41.0"
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -47,28 +47,40 @@ def gather_default_paths() -> list[str]:
     return [str(path) for path in unique_paths]
 
 
+def parse_version(version_output: str) -> tuple[int, int, int] | None:
+    """Parse a semantic version from markdownlint output."""
+    parts = version_output.strip().split(".")
+    if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        return None
+    return int(parts[0]), int(parts[1]), int(parts[2])
+
+
 def resolve_markdownlint() -> tuple[str, str]:
     """Resolve markdownlint binary and version."""
     markdownlint = shutil.which("markdownlint")
-    if markdownlint:
-        version_output = subprocess.run(
-            (markdownlint, "--version"), check=True, text=True, capture_output=True
-        ).stdout.strip()
-        if version_output != MARKDOWNLINT_VERSION:
-            raise SystemExit(
-                "markdownlint version mismatch. "
-                f"Expected {MARKDOWNLINT_VERSION}, found {version_output}."
-            )
-        return markdownlint, version_output
-
-    npx = shutil.which("npx")
-    if not npx:
+    if not markdownlint:
         raise SystemExit(
             "markdownlint is required for docs-only validation. "
-            "Install markdownlint or ensure npx is available."
+            f"Install markdownlint >= {MIN_MARKDOWNLINT_VERSION} and ensure it is on PATH."
         )
 
-    return npx, MARKDOWNLINT_VERSION
+    version_output = subprocess.run(
+        (markdownlint, "--version"), check=True, text=True, capture_output=True
+    ).stdout.strip()
+    parsed_version = parse_version(version_output)
+    if not parsed_version:
+        raise SystemExit(
+            "Unable to parse markdownlint version output: "
+            f"{version_output!r}."
+        )
+
+    minimum = parse_version(MIN_MARKDOWNLINT_VERSION)
+    if parsed_version < minimum:
+        raise SystemExit(
+            "markdownlint version too old. "
+            f"Expected >= {MIN_MARKDOWNLINT_VERSION}, found {version_output}."
+        )
+    return markdownlint, version_output
 
 
 def run_markdownlint(paths: list[str]) -> int:
@@ -79,10 +91,7 @@ def run_markdownlint(paths: list[str]) -> int:
         print("No markdown files found to validate.")
         return 0
 
-    if markdownlint_cmd.endswith("markdownlint"):
-        command = (markdownlint_cmd, *paths)
-    else:
-        command = (markdownlint_cmd, "--yes", f"markdownlint-cli@{version}", *paths)
+    command = (markdownlint_cmd, *paths)
     print(f"Running: {' '.join(command)}")
     return subprocess.run(command).returncode
 


### PR DESCRIPTION
# Pull Request

## Summary
- Clarify that non-docs-only changes require the canonical validation command.
- Require markdownlint >= 0.41.0 and remove the npx fallback.
- Fix markdownlint violations in existing docs (headings, lists, code fences, links).

## Issue Linkage
- Ref #14

## Testing
- Running: /usr/local/bin/markdownlint README.md docs/decisions/0001-repo-structure.md docs/development/environment-and-tooling.md docs/development/overview.md docs/development/tooling-dependencies.md docs/development/validation.md docs/operations/2026-01-20-bootstrap-log.md docs/operations/2026-01-21-uv-migration.md docs/repository-standards.md docs/standards-and-conventions.md

## Notes
- Placeholder docs now have H1 headings to satisfy markdownlint.